### PR TITLE
Fix the situation that running an Icecast server behind the Apache server

### DIFF
--- a/src/slave.c
+++ b/src/slave.c
@@ -649,7 +649,7 @@ static int update_from_master(ice_config_t *config)
         free(data);
 
         if (sock_read_line(mastersock, buf, sizeof(buf)) == 0 ||
-                strncmp (buf, "HTTP/1.0 200", 12) != 0)
+                (strncmp (buf, "HTTP/1.0 200", 12) != 0) && (strncmp (buf, "HTTP/1.1 200", 12) != 0))
         {
             sock_close (mastersock);
             ICECAST_LOG_WARN("Master rejected streamlist request");

--- a/src/slave.c
+++ b/src/slave.c
@@ -641,7 +641,10 @@ static int update_from_master(ice_config_t *config)
         sock_write (mastersock,
                 "GET /admin/streamlist.txt HTTP/1.0\r\n"
                 "Authorization: Basic %s\r\n"
-                "\r\n", data);
+                "Host: %s\r\n"
+                "\r\n",
+                data,
+                master);
         free(authheader);
         free(data);
 


### PR DESCRIPTION
Hi,

I'm running an Icecast server on the OpenShift. Since the OpenShift is virtual hosting, so I have to send a packet with a Host header, so that the OpenShift can recognize the packet.

And the Apache on OpenShift always return `HTTP/1.1` instead of `HTTP/1.0`. I don't have permission to force it returning `HTTP/1.0`. So I can only modify the client side.

It would be great if Icecast can officially support the situation that running an Icecast server behind the Apache server. Thank you.