### PR TITLE
Master-Slave Aggregating Relay (multiple master setup)

### DIFF
--- a/conf/icecast.xml.in
+++ b/conf/icecast.xml.in
@@ -118,6 +118,7 @@
         <port>8001</port>
         <username>relay</username>
         <password>hackme</password>
+        <namespace>master1</namespace>
         <on-demand>1</on-demand>
     </master>
     -->

--- a/conf/icecast.xml.in
+++ b/conf/icecast.xml.in
@@ -108,6 +108,20 @@
     <!--<master-update-interval>120</master-update-interval>-->
     <!--<master-password>hackme</master-password>-->
 
+    <!-- Aggregation
+         useful for aggregating all the mounts of any number of master relays.
+    -->
+
+    <!--
+    <master>
+        <server>127.0.0.1</server>
+        <port>8001</port>
+        <username>relay</username>
+        <password>hackme</password>
+        <on-demand>1</on-demand>
+    </master>
+    -->
+
     <!-- Setting this makes all relays on-demand unless overridden, this is
          useful for master relays which do not have <relay> definitions here.
          The default is 0 -->

--- a/doc/relaying.html
+++ b/doc/relaying.html
@@ -35,6 +35,9 @@ can be setup such that all that needs to be done is configure the slave server w
 will also periodically check the master server to see if any new mountpoints have attached and if so will relay those
 as well.  </p>
 
+  <p>This "master-slave" type relay has been extended to support aggregation so that multiple masters can be given
+and the slave will "aggregate" all of the mountpoints for those master servers. </p>
+
   <p>The second type of relay is a “single-broadcast” relay. In this case, the slave server is configured with a
 server IP, port and mount and only the mountpoint specified is relayed. In order to relay a broadcast stream on
 a Shoutcast server, you must use the “single-broadcast” relay and specify a mountpoint of <code>/</code>.</p>
@@ -58,6 +61,36 @@ and will begin to relay all mountpoints connected to the master server. Addition
 (120 seconds in this case) the slave server will poll the master server to see if any new mountpoints have connected,
 and if so, the slave server will relay those as well. Note that the names of the mountpoints on the slave server will
 be identical to those on the master server. </p>
+
+</div>
+
+<div class="article">
+  <h3 id="setting-up-a-master-slave-aggregating-relay">Setting Up a Master-Slave Aggregating Relay</h3>
+  <p>In order to setup a relay of this type all servers (the one you wish to relay and the one doing the relaying)
+need to be Icecast 2 servers. The following configuration snippet is used as an example:</p>
+
+  <div class="highlight"><pre><code class="language-xml" data-lang="xml"><span class="nt">&lt;master-update-interval&gt;</span>120<span class="nt">&lt;/master-update-interval&gt;</span>
+<span class="nt">&lt;master&gt;</span>
+    <span class="nt">&lt;server&gt;</span>192.168.1.11<span class="nt">&lt;/server&gt;</span>
+    <span class="nt">&lt;port&gt;</span>8001<span class="nt">&lt;/port&gt;</span>
+    <span class="nt">&lt;namespace&gt;</span>/upstream1<span class="nt">&lt;/namespace&gt;</span>
+    <span class="nt">&lt;password&gt;</span>hackme<span class="nt">&lt;/password&gt;</span>
+    <span class="nt">&lt;on-demand&gt;</span>1<span class="nt">&lt;/on-demand&gt;</span>
+<span class="nt">&lt;/master&gt;</span>
+<span class="nt">&lt;master&gt;</span>
+    <span class="nt">&lt;server&gt;</span>192.168.1.12<span class="nt">&lt;/server&gt;</span>
+    <span class="nt">&lt;port&gt;</span>8001<span class="nt">&lt;/port&gt;</span>
+    <span class="nt">&lt;password&gt;</span>hackme<span class="nt">&lt;/password&gt;</span>
+<span class="nt">&lt;/master&gt;</span>
+</code></pre></div>
+
+  <p>In this example, this configuration is setup in the server which will be doing the relaying (slave server).
+The master servers in this case need not be configured (and actually they are unaware of the relaying being performed)
+as relays. When the slave server is started, it will connect to each of the master servers located at 192.168.1.11:8001
+and 192.168.1.12:8001 and will begin to relay all mountpoints connected to the master servers. Additionally,
+every master-update-interval (120 seconds in this case) the slave server will poll the master servers to see if any new
+mountpoints have connected, and if so, the slave server will relay those as well. Note that all mountpoints of the master
+server at 192.168.1.11:8001 will have the namespace "/upstream1" prepended to it's mountpoints. </p>
 
 </div>
 

--- a/src/cfgfile.c
+++ b/src/cfgfile.c
@@ -1612,7 +1612,8 @@ static void _parse_master(xmlDocPtr      doc,
     master->on_demand    = configuration->on_demand;
     master->server       = (char *) xmlCharStrdup("127.0.0.1");
     master->username     = (char *) xmlCharStrdup(configuration->master_username);
-    master->password     = (char *) xmlCharStrdup(configuration->master_password);
+    if (configuration->master_password)
+        master->password = (char *) xmlCharStrdup(configuration->master_password);
 
     do {
         if (node == NULL)

--- a/src/cfgfile.c
+++ b/src/cfgfile.c
@@ -1644,6 +1644,11 @@ static void _parse_master(xmlDocPtr      doc,
                 xmlFree(master->password);
             master->password = (char *)xmlNodeListGetString(doc, 
                 node->xmlChildrenNode, 1);
+        } else if (xmlStrcmp(node->name, XMLSTR("namespace")) == 0) {
+            if (master->namespace)
+                xmlFree(master->namespace);
+            master->namespace = (char *)xmlNodeListGetString(doc, 
+                node->xmlChildrenNode, 1);
         } else if (xmlStrcmp(node->name, XMLSTR("on-demand")) == 0) {
             tmp = (char *)xmlNodeListGetString(doc, node->xmlChildrenNode, 1);
             master->on_demand = util_str_to_bool(tmp);

--- a/src/cfgfile.c
+++ b/src/cfgfile.c
@@ -133,6 +133,7 @@ static void _parse_http_headers(xmlDocPtr                   doc,
                                 xmlNodePtr                  node,
                                 ice_config_http_header_t  **http_headers);
 
+static void _parse_master(xmlDocPtr doc, xmlNodePtr node, ice_config_t *c);
 static void _parse_relay(xmlDocPtr doc, xmlNodePtr node, ice_config_t *c);
 static void _parse_mount(xmlDocPtr doc, xmlNodePtr node, ice_config_t *c);
 
@@ -487,6 +488,7 @@ void config_clear(ice_config_t *c)
 {
     ice_config_dir_t    *dirnode,
                         *nextdirnode;
+    master_server        *master;
     relay_server        *relay,
                         *nextrelay;
     mount_proxy         *mount,
@@ -528,6 +530,11 @@ void config_clear(ice_config_t *c)
     event_registration_release(c->event);
 
     while ((c->listen_sock = config_clear_listener(c->listen_sock)));
+
+    master = c->master;
+    while (master) {
+        master = master_free(master);
+    }
 
     thread_mutex_lock(&(_locks.relay_lock));
     relay = c->relay;
@@ -934,6 +941,8 @@ static void _parse_root(xmlDocPtr       doc,
             _parse_limits(doc, node->xmlChildrenNode, configuration);
         } else if (xmlStrcmp(node->name, XMLSTR("http-headers")) == 0) {
             _parse_http_headers(doc, node->xmlChildrenNode, &(configuration->http_headers));
+        } else if (xmlStrcmp(node->name, XMLSTR("master")) == 0) {
+            _parse_master(doc, node->xmlChildrenNode, configuration);
         } else if (xmlStrcmp(node->name, XMLSTR("relay")) == 0) {
             _parse_relay(doc, node->xmlChildrenNode, configuration);
         } else if (xmlStrcmp(node->name, XMLSTR("mount")) == 0) {
@@ -1577,6 +1586,70 @@ static void _parse_http_headers(xmlDocPtr                   doc,
         xmlFree(name);
     if (value)
         xmlFree(value);
+}
+
+static void _parse_master(xmlDocPtr      doc,
+                         xmlNodePtr     node,
+                         ice_config_t  *configuration)
+{
+    char         *tmp;
+    master_server *master     = calloc(1, sizeof(master_server));
+    master_server *current   = configuration->master;
+    master_server *last      = NULL;
+
+    while(current) {
+        last = current;
+        current = current->next;
+    }
+
+    if (last) {
+        last->next = master;
+    } else {
+        configuration->master = master;
+    }
+
+    master->next         = NULL;
+    master->on_demand    = configuration->on_demand;
+    master->server       = (char *) xmlCharStrdup("127.0.0.1");
+    master->username     = (char *) xmlCharStrdup(configuration->master_username);
+    master->password     = (char *) xmlCharStrdup(configuration->master_password);
+
+    do {
+        if (node == NULL)
+            break;
+        if (xmlIsBlankNode(node))
+            continue;
+
+        if (xmlStrcmp(node->name, XMLSTR("server")) == 0) {
+            if (master->server)
+                xmlFree(master->server);
+            master->server = (char *)xmlNodeListGetString(doc,
+                node->xmlChildrenNode, 1);
+        } else if (xmlStrcmp(node->name, XMLSTR("port")) == 0) {
+            tmp = (char *)xmlNodeListGetString(doc, node->xmlChildrenNode, 1);
+            if (tmp) {
+                master->port = atoi(tmp);
+                xmlFree(tmp);
+            } else {
+                ICECAST_LOG_WARN("<port> setting must not be empty.");
+            }
+        } else if (xmlStrcmp(node->name, XMLSTR("username")) == 0) {
+            if (master->username)
+                xmlFree(master->username);
+            master->username = (char *)xmlNodeListGetString(doc,
+                node->xmlChildrenNode, 1);
+        } else if (xmlStrcmp(node->name, XMLSTR("password")) == 0) {
+            if (master->password)
+                xmlFree(master->password);
+            master->password = (char *)xmlNodeListGetString(doc, 
+                node->xmlChildrenNode, 1);
+        } else if (xmlStrcmp(node->name, XMLSTR("on-demand")) == 0) {
+            tmp = (char *)xmlNodeListGetString(doc, node->xmlChildrenNode, 1);
+            master->on_demand = util_str_to_bool(tmp);
+            if (tmp)
+                xmlFree(tmp);
+        }
+    } while ((node = node->next));
 }
 
 static void _parse_relay(xmlDocPtr      doc,

--- a/src/cfgfile.h
+++ b/src/cfgfile.h
@@ -218,6 +218,7 @@ typedef struct ice_config_tag {
     /* is TLS supported by the server? */
     int tls_ok;
 
+    master_server *master;
     relay_server *relay;
 
     mount_proxy *mounts;

--- a/src/slave.c
+++ b/src/slave.c
@@ -67,16 +67,20 @@ static mutex_t _slave_mutex; // protects update_settings, update_all_mounts, max
 /* free a master and return its next master */
 master_server *master_free(master_server *master)
 {
-    master_server *next = master->next;
-    ICECAST_LOG_DEBUG("freeing master %s:%d", master->server, master->port);
-    xmlFree(master->server);
-    if (master->username)
-        xmlFree(master->username);
-    if (master->password)
-        xmlFree(master->password);
-    if (master->namespace)
-        xmlFree(master->namespace);
-    free(master);
+    master_server *next = NULL;
+    if (master)
+    {
+        next = master->next;
+        ICECAST_LOG_DEBUG("freeing master %s:%d", master->server, master->port);
+        xmlFree(master->server);
+        if (master->username)
+            xmlFree(master->username);
+        if (master->password)
+            xmlFree(master->password);
+        if (master->namespace)
+            xmlFree(master->namespace);
+        free(master);
+    }
     return next;
 }
 
@@ -869,8 +873,7 @@ static void *_slave_thread(void *arg)
                 list = list->next;
             }
 
-            if (list)
-                master_list_free(list);
+            master_list_free(list);
 
             config = config_get_config();
 

--- a/src/slave.c
+++ b/src/slave.c
@@ -723,6 +723,7 @@ static int update_from_master_legacy(ice_config_t *config)
         if (config->master_server)
             master->server = strdup(config->master_server);
         master->port = config->master_server_port;
+        master->on_demand = config->on_demand;
         ret = update_from_master(master);
         master_free(master);
     }

--- a/src/slave.c
+++ b/src/slave.c
@@ -72,6 +72,8 @@ master_server *master_free (master_server *master)
         xmlFree (master->username);
     if (master->password)
         xmlFree (master->password);
+    if (master->namespace)
+        xmlFree(master->namespace);
     free (master);
     return next;
 }
@@ -686,7 +688,14 @@ static int update_from_master(master_server *master)
                 }
 
                 r->mount = strdup(parsed_uri->path);
-                r->localmount = strdup(parsed_uri->path);
+                if (master->namespace)
+                {
+                    int mountlen = strlen(master->namespace) + strlen(parsed_uri->path) + 1;
+                    r->localmount = malloc(mountlen);
+                    snprintf(r->localmount, mountlen, "%s%s", master->namespace, parsed_uri->path);
+                } else {
+                    r->localmount = strdup(parsed_uri->path);
+                }
                 r->mp3metadata = 1;
                 r->on_demand = master->on_demand;
                 r->next = new_relays;

--- a/src/slave.h
+++ b/src/slave.h
@@ -21,6 +21,7 @@ typedef struct _master_server {
     char *username;
     char *password;
     int on_demand;
+    char *namespace;
     struct _master_server *next;
 } master_server;
 

--- a/src/slave.h
+++ b/src/slave.h
@@ -15,6 +15,15 @@
 
 #include "common/thread/thread.h"
 
+typedef struct _master_server {
+    char *server;
+    int port;
+    char *username;
+    char *password;
+    int on_demand;
+    struct _master_server *next;
+} master_server;
+
 typedef struct _relay_server {
     char *server;
     int port;
@@ -33,6 +42,8 @@ typedef struct _relay_server {
     struct _relay_server *next;
 } relay_server;
 
+
+master_server *master_free (master_server *master);
 
 void slave_initialize(void);
 void slave_shutdown(void);


### PR DESCRIPTION
This pull request adds support for multiple Master-Slave relays. Something I am calling a Master-Slave Aggregating Relay.

A couple of people have asked for this feature in the past and were referred to the Single-Broadcast Relay, which is OK provided you know the specific mountpoints that you want to relay ahead of time.

If you are in a position where you want to relay mountpoints for more than one the master server, and one or more of the master servers adds and removes mountpoints dynamically or if you are unable to know what mountpoints are available ahead of time then this gives you the ability to aggregate all mountpoints for any numbers of master servers.

Namespacing is also supported to prevent name clashes for mountpoints being relayed from different servers.