### PR TITLE
Fix: Postpone signal handling to avoid deadlocks

### DIFF
--- a/src/sighandler.h
+++ b/src/sighandler.h
@@ -15,6 +15,7 @@
 #define __SIGHANDLER_H__
 
 void sighandler_initialize(void);
+void sighandler_handle_pending(void);
 
 
 #endif  /* __SIGHANDLER_H__ */

--- a/src/slave.c
+++ b/src/slave.c
@@ -55,6 +55,7 @@
 #include "source.h"
 #include "format.h"
 #include "prng.h"
+#include "sighandler.h"
 
 #define CATMODULE "slave"
 
@@ -906,6 +907,9 @@ static void *_slave_thread(void *arg)
     {
         relay_t *cleanup_relays = NULL;
         int skip_timer = 0;
+
+        /* handle any pending signals */
+        sighandler_handle_pending();
 
         /* re-read xml file if requested */
         global_lock();


### PR DESCRIPTION
Currently the signal handler will do two things:

- Log that we've received a signal
- Flag a global variable

Unfortunately these both require locks (though _sig_die doesn't currently lock global variables, this is fixed too), and as signal handlers can run at any time it's possible to deadlock the server.

Solve this entirely by moving signal handling code out of signal handlers and having the slave handle logging and flagging variables.

This new code changes semantics slightly: Multiple signals are treated as one signal. In the case of telling the server to reload or shutdown this isn't as important as avoiding deadlocking.

---

Note: I've posted this here as the GitLab instance doesn't support merge requests. Have fun.