### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pre-built packages (eg rpm, deb etc).  These setups often have a runtime
 package, which is usually installed for you by default, and enables you
 to run applications that depend on them.  However if you are building
 Icecast from source then the runtime system is not enough. You will also
-need a development package named something like libxslt-devel
+need a development package named something like libxslt-devel on certain distributions like Debian and Ubuntu.
 
 Build/Install
 ---------------------------------------------------------------------


### PR DESCRIPTION
Not all distros split development packages out of the original source, I adjusted the README to be correct about that.

Arch users as example could otherwise look for packages that don't exist (since that stuff is casually still in the normal package.)